### PR TITLE
채팅 플러스 메뉴 구현(1) #30

### DIFF
--- a/app/src/main/java/com/fitmate/fitmate/data/model/dto/GroupDto.kt
+++ b/app/src/main/java/com/fitmate/fitmate/data/model/dto/GroupDto.kt
@@ -85,3 +85,21 @@ data class VoteCertification(
     @SerializedName("voteEndDate") val voteEndDate: String,
     @SerializedName("recordMultiMediaEndPoints") val multiMediaEndPoints: List<String>
 )
+
+data class EachFitResponse(
+    val fitCertificationDetails: List<GroupCertificationDetail>
+)
+
+data class GroupCertificationDetail(
+    val certificationId: Int,
+    val recordId: Int,
+    val certificationRequestUserId: String,
+    val isUserVoteDone: Boolean,
+    val isUserAgree: Boolean,
+    val agreeCount: Int,
+    val disagreeCount: Int,
+    val maxAgreeCount: Int,
+    val fitRecordStartDate: String,
+    val fitRecordEndDate: String,
+    val voteEndDate: String
+)

--- a/app/src/main/java/com/fitmate/fitmate/data/repository/GroupRepositoryImpl.kt
+++ b/app/src/main/java/com/fitmate/fitmate/data/repository/GroupRepositoryImpl.kt
@@ -1,10 +1,12 @@
 package com.fitmate.fitmate.data.repository
 
+import com.fitmate.fitmate.data.model.dto.EachFitResponse
 import com.fitmate.fitmate.data.model.dto.GroupDetailResponse
 import com.fitmate.fitmate.data.model.dto.GroupResponse
 import com.fitmate.fitmate.data.model.dto.MyFitGroupVote
 import com.fitmate.fitmate.data.source.remote.GroupService
 import com.fitmate.fitmate.domain.repository.GroupRepository
+import retrofit2.Response
 
 class GroupRepositoryImpl(private val groupService: GroupService) : GroupRepository {
     override suspend fun getFilteredFitGroups(withMaxGroup: Boolean, category: Int, pageNumber: Int, pageSize: Int): GroupResponse {
@@ -17,7 +19,11 @@ class GroupRepositoryImpl(private val groupService: GroupService) : GroupReposit
         return groupService.getGroupDetail()
     }
 
-    override suspend fun fetchFitVotes(): Result<List<MyFitGroupVote>> {
+    override suspend fun myFitGroupVotes(): Result<List<MyFitGroupVote>> {
         return Result.success(groupService.getMyFitGroupVotes().body()!!.fitGroupList)
+    }
+
+    override suspend fun getEachGroupVotes(): Response<EachFitResponse> {
+        return groupService.getEachFitGroupVotes()
     }
 }

--- a/app/src/main/java/com/fitmate/fitmate/data/source/remote/GroupService.kt
+++ b/app/src/main/java/com/fitmate/fitmate/data/source/remote/GroupService.kt
@@ -1,5 +1,6 @@
 package com.fitmate.fitmate.data.source.remote
 
+import com.fitmate.fitmate.data.model.dto.EachFitResponse
 import com.fitmate.fitmate.data.model.dto.GroupDetailResponse
 import com.fitmate.fitmate.data.model.dto.GroupResponse
 import com.fitmate.fitmate.data.model.dto.MyFitResponse
@@ -33,4 +34,7 @@ interface GroupService {
 //    ): Response<MyFitResponse>
     @GET("70e08fe2-49a8-4426-a99f-016610cbc104")
     suspend fun getMyFitGroupVotes(): Response<MyFitResponse>
+
+    @GET("19e89fb6-dad0-4cdc-acc3-7a26603f2cad")
+    suspend fun getEachFitGroupVotes(): Response<EachFitResponse>
 }

--- a/app/src/main/java/com/fitmate/fitmate/di/networkModule/GroupModule.kt
+++ b/app/src/main/java/com/fitmate/fitmate/di/networkModule/GroupModule.kt
@@ -15,7 +15,7 @@ import javax.inject.Singleton
 object GroupModule {
     @Provides
     @Singleton
-    fun provideCategoryService(retrofit: Retrofit): GroupService {
+    fun provideGroupService(retrofit: Retrofit): GroupService {
         // val fitGroupBaseUrl = "http://43.202.247.71:8080"
         val fitGroupBaseUrl = "https://run.mocky.io/v3/"
         return retrofit.newBuilder()

--- a/app/src/main/java/com/fitmate/fitmate/domain/model/VoteItem.kt
+++ b/app/src/main/java/com/fitmate/fitmate/domain/model/VoteItem.kt
@@ -7,4 +7,6 @@ data class VoteItem(
     val time: String,
     val image: String,
     val groupId: Int,
+    val startTime: String?,
+    val endTime: String?,
 )

--- a/app/src/main/java/com/fitmate/fitmate/domain/repository/GroupRepository.kt
+++ b/app/src/main/java/com/fitmate/fitmate/domain/repository/GroupRepository.kt
@@ -1,13 +1,17 @@
 package com.fitmate.fitmate.domain.repository
 
+import com.fitmate.fitmate.data.model.dto.EachFitResponse
 import com.fitmate.fitmate.data.model.dto.GroupDetailResponse
 import com.fitmate.fitmate.data.model.dto.GroupResponse
 import com.fitmate.fitmate.data.model.dto.MyFitGroupVote
+import retrofit2.Response
 
 interface GroupRepository {
     suspend fun getFilteredFitGroups(withMaxGroup: Boolean, category: Int, pageNumber: Int, pageSize: Int): GroupResponse
 
     suspend fun getFitGroupDetail(fitGroupId: Int): GroupDetailResponse
 
-    suspend fun fetchFitVotes(): Result<List<MyFitGroupVote>>
+    suspend fun myFitGroupVotes(): Result<List<MyFitGroupVote>>
+
+    suspend fun getEachGroupVotes(): Response<EachFitResponse>
 }

--- a/app/src/main/java/com/fitmate/fitmate/domain/usecase/GroupUseCase.kt
+++ b/app/src/main/java/com/fitmate/fitmate/domain/usecase/GroupUseCase.kt
@@ -1,9 +1,11 @@
 package com.fitmate.fitmate.domain.usecase
 
+import com.fitmate.fitmate.data.model.dto.EachFitResponse
 import com.fitmate.fitmate.data.model.dto.GroupDetailResponse
 import com.fitmate.fitmate.data.model.dto.GroupResponse
 import com.fitmate.fitmate.data.model.dto.MyFitGroupVote
 import com.fitmate.fitmate.domain.repository.GroupRepository
+import retrofit2.Response
 import javax.inject.Inject
 
 class GroupUseCase @Inject constructor(private val groupRepository: GroupRepository) {
@@ -13,5 +15,7 @@ class GroupUseCase @Inject constructor(private val groupRepository: GroupReposit
 
     suspend operator fun invoke(fitGroupId: Int): GroupDetailResponse =groupRepository.getFitGroupDetail(fitGroupId)
 
-    suspend fun fetchFitVotes(): Result<List<MyFitGroupVote>> = groupRepository.fetchFitVotes()
+    suspend fun myFitGroupVotes(): Result<List<MyFitGroupVote>> = groupRepository.myFitGroupVotes()
+
+    suspend fun eachFitGroupVotes(): Response<EachFitResponse> = groupRepository.getEachGroupVotes()
 }

--- a/app/src/main/java/com/fitmate/fitmate/presentation/ui/chatting/GroupVoteFragment.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/ui/chatting/GroupVoteFragment.kt
@@ -11,13 +11,21 @@ import androidx.navigation.ui.setupWithNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.fitmate.fitmate.R
+import com.fitmate.fitmate.data.model.dto.GroupCertificationDetail
 import com.fitmate.fitmate.databinding.FragmentGroupVoteBinding
 import com.fitmate.fitmate.domain.model.VoteItem
 import com.fitmate.fitmate.presentation.ui.chatting.list.adapter.GroupVoteAdapter
+import com.fitmate.fitmate.presentation.viewmodel.GroupViewModel
+import com.fitmate.fitmate.util.ControlActivityInterface
+import dagger.hilt.android.AndroidEntryPoint
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
+@AndroidEntryPoint
 class GroupVoteFragment: Fragment(R.layout.fragment_group_vote) {
 
     private lateinit var binding: FragmentGroupVoteBinding
+    private val viewModel: GroupViewModel by viewModels()
     private var groupId = -1
 
 
@@ -30,18 +38,57 @@ class GroupVoteFragment: Fragment(R.layout.fragment_group_vote) {
             Log.d("woojugoing_group_id", groupId.toString())
             Toast.makeText(context, "Error: Group not found!", Toast.LENGTH_SHORT).show()
         }
+        viewModel.fetchFitGroupVotes()
     }
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding = FragmentGroupVoteBinding.bind(view)
+        (activity as? ControlActivityInterface)?.goneNavigationBar()
         binding.materialToolbarGroupVote.setupWithNavController(findNavController())
 
         val recyclerView: RecyclerView = binding.recyclerGroupVote
-        val adapter = GroupVoteAdapter {}
+        val adapter = GroupVoteAdapter(this) {}
 
         recyclerView.layoutManager = LinearLayoutManager(context)
-        val testItems = listOf(VoteItem(title = "Test FitGroup", fitMate = "김성호", percent = 3, time = "5", image = "5", groupId = 3))
         recyclerView.adapter = adapter
-        adapter.submitList(testItems)
+
+        viewModel.fitGroupVotes.observe(viewLifecycleOwner) { eachFitResponse ->
+            stopShimmer()
+            val voteItems = eachFitResponse.fitCertificationDetails.map { detail ->
+                VoteItem(
+                    title = detail.recordId.toString(),
+                    fitMate = detail.certificationRequestUserId,
+                    percent = formatPercent(detail),  // 투표율 계산
+                    time = formatDate(detail),
+                    image = "이미지 URL",  // 필요한 경우 이미지 URL 설정
+                    groupId = groupId,
+                    startTime = detail.fitRecordStartDate,  // 기록 시작일
+                    endTime = detail.fitRecordEndDate       // 기록 종료일
+                )
+            }
+            adapter.submitList(voteItems)
+        }
+    }
+
+    private fun startShimmer() {
+        binding.groupVoteShimmer.startShimmer()
+        binding.groupVoteShimmer.visibility = View.VISIBLE
+        binding.recyclerGroupVote.visibility = View.GONE
+    }
+
+    private fun stopShimmer() {
+        binding.groupVoteShimmer.stopShimmer()
+        binding.groupVoteShimmer.visibility = View.GONE
+        binding.recyclerGroupVote.visibility = View.VISIBLE
+    }
+
+    private fun formatPercent(detail: GroupCertificationDetail): Int {
+        return if (detail.agreeCount + detail.disagreeCount > 0) (detail.agreeCount * 100) / (detail.agreeCount + detail.disagreeCount) else 0
+    }
+
+    private fun formatDate(detail: GroupCertificationDetail): String {
+        return ZonedDateTime.parse(detail.voteEndDate).format(
+            DateTimeFormatter.ofPattern("(MM/dd) HH:mm 종료")
+        )
     }
 }

--- a/app/src/main/java/com/fitmate/fitmate/presentation/ui/chatting/list/GroupVoteViewHolder.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/ui/chatting/list/GroupVoteViewHolder.kt
@@ -1,12 +1,66 @@
 package com.fitmate.fitmate.presentation.ui.chatting.list
 
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.TextView
+import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
+import com.fitmate.fitmate.R
 import com.fitmate.fitmate.databinding.ItemVoteBinding
 import com.fitmate.fitmate.domain.model.VoteItem
+import com.fitmate.fitmate.presentation.ui.chatting.list.adapter.VoteViewPageAdapter
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
-class GroupVoteViewHolder(private val binding: ItemVoteBinding, val onClick: (VoteItem) -> Unit): RecyclerView.ViewHolder(binding.root){
+class GroupVoteViewHolder(private val binding: ItemVoteBinding, val fragment: Fragment, val onClick: (VoteItem) -> Unit): RecyclerView.ViewHolder(binding.root){
     fun bind(item: VoteItem) {
         binding.voteItem = item
-        binding.root.setOnClickListener { onClick(item) }
+        binding.buttonItemVoteFitgroupVote.setOnClickListener {
+            val dialog = MaterialAlertDialogBuilder(fragment.requireContext())
+            dialog.run {
+                setVoteCustomDialog(item)
+            }
+        }
     }
+
+    private fun MaterialAlertDialogBuilder.setVoteCustomDialog(item: VoteItem) {
+        val dialogView = LayoutInflater.from(fragment.context).inflate(R.layout.dialog_vote_image_slider, null)
+        val viewPager: ViewPager2 = dialogView.findViewById(R.id.viewPagerDialogVote)
+        val hourDescription: TextView = dialogView.findViewById(R.id.textViewDialogVoteHour)
+        val timeDescription: TextView = dialogView.findViewById(R.id.textViewDialogVoteTime)
+        val imageUrls = listOf(item.image, item.image, item.image)
+        val startTime = Instant.parse(item.startTime).atZone(ZoneId.of("Asia/Seoul"))
+        val endTime = Instant.parse(item.endTime).atZone(ZoneId.of("Asia/Seoul"))
+        val duration = Duration.between(startTime, endTime)
+        val hours = duration.toHours()
+        val minutes = duration.toMinutes() % 60
+
+        bindDialog(viewPager, imageUrls, hourDescription, startTime, endTime, timeDescription, hours, minutes, item, dialogView)
+    }
+
+    private fun MaterialAlertDialogBuilder.bindDialog(
+        viewPager: ViewPager2, imageUrls: List<String>, hourDescription: TextView,
+        startTime: ZonedDateTime, endTime: ZonedDateTime, timeDescription: TextView,
+        hours: Long, minutes: Long, item: VoteItem, dialogView: View?
+    ) {
+        viewPager.adapter = VoteViewPageAdapter(imageUrls)
+        hourDescription.text = "측정 시각 : ${formatDate(startTime)} ~ ${formatDate(endTime)}"
+        timeDescription.text = "총 운동 시간 : ${hours}시간 ${minutes}분"
+
+        setIcon(R.drawable.ic_baseline_timer_24)
+        setTitle("${item.fitMate} 님의 운동 기록")
+        setView(dialogView)
+        setNeutralButton("보류") { dialog, which -> null }
+        setNegativeButton("반대") { dialog, which -> /* TODO {"requestUserId":"testUserId","agree":true,"targetCategory":1,"targetId":13} /my-fit-service/votes 으로 false 통신 */ }
+        setPositiveButton("찬성") { dialog, which -> /* TODO {"requestUserId":"testUserId","agree":true,"targetCategory":1,"targetId":13} /my-fit-service/votes 으로 true 통신 */ }
+        show()
+    }
+
+    private fun formatDate(time:ZonedDateTime): String = time.format(DateTimeFormatter.ofPattern("'['MM/dd']' HH:mm"))
+
 }

--- a/app/src/main/java/com/fitmate/fitmate/presentation/ui/chatting/list/adapter/GroupVoteAdapter.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/ui/chatting/list/adapter/GroupVoteAdapter.kt
@@ -2,17 +2,18 @@ package com.fitmate.fitmate.presentation.ui.chatting.list.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.fitmate.fitmate.databinding.ItemVoteBinding
 import com.fitmate.fitmate.domain.model.VoteItem
 import com.fitmate.fitmate.presentation.ui.chatting.list.GroupVoteViewHolder
 
-class GroupVoteAdapter(private val onclick: (VoteItem) -> Unit):
+class GroupVoteAdapter(private val fragment: Fragment, private val onclick: (VoteItem) -> Unit):
     ListAdapter<VoteItem, GroupVoteViewHolder>(VoteItemDiffCallback) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GroupVoteViewHolder {
         val binding = ItemVoteBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return GroupVoteViewHolder(binding, onclick)
+        return GroupVoteViewHolder(binding, fragment, onclick)
     }
 
     override fun onBindViewHolder(holder: GroupVoteViewHolder, position: Int) {

--- a/app/src/main/java/com/fitmate/fitmate/presentation/ui/chatting/list/adapter/VoteViewPageAdapter.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/ui/chatting/list/adapter/VoteViewPageAdapter.kt
@@ -1,0 +1,29 @@
+package com.fitmate.fitmate.presentation.ui.chatting.list.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.fitmate.fitmate.R
+
+class VoteViewPageAdapter(private val imageUrls: List<String>) : RecyclerView.Adapter<VoteViewPageAdapter.SliderViewHolder>() {
+
+    inner class SliderViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val imageView: ImageView = itemView.findViewById(R.id.imageView)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SliderViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_image, parent, false)
+        return SliderViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: SliderViewHolder, position: Int) {
+        Glide.with(holder.itemView.context).load(imageUrls[position]).into(holder.imageView)
+    }
+
+    override fun getItemCount(): Int {
+        return imageUrls.size
+    }
+}

--- a/app/src/main/java/com/fitmate/fitmate/presentation/ui/home/GroupJoinFragment.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/ui/home/GroupJoinFragment.kt
@@ -13,7 +13,7 @@ import androidx.viewpager2.widget.ViewPager2
 import com.fitmate.fitmate.R
 import com.fitmate.fitmate.data.model.dto.GroupDetailResponse
 import com.fitmate.fitmate.databinding.FragmentGroupJoinBinding
-import com.fitmate.fitmate.presentation.ui.home.list.adapter.ImageSliderAdapter
+import com.fitmate.fitmate.presentation.ui.home.list.adapter.HomeViewPageAdapter
 import com.fitmate.fitmate.presentation.viewmodel.GroupViewModel
 import com.fitmate.fitmate.util.ControlActivityInterface
 import dagger.hilt.android.AndroidEntryPoint
@@ -55,7 +55,7 @@ class GroupJoinFragment: Fragment(R.layout.fragment_group_join) {
 
     private fun updateUI(groupDetail: GroupDetailResponse) {
         binding.run {
-            val adapter = ImageSliderAdapter(requireContext(), groupDetail.multiMediaEndPoints)
+            val adapter = HomeViewPageAdapter(requireContext(), groupDetail.multiMediaEndPoints)
             imageViewItemDayCurrentDate.adapter = adapter
 
             toolbarGroupJoin.title = groupDetail.fitGroupName
@@ -83,7 +83,7 @@ class GroupJoinFragment: Fragment(R.layout.fragment_group_join) {
     }
 
     private fun setupImageSlider(images: List<String>) {
-        val adapter = ImageSliderAdapter(requireContext(), images)
+        val adapter = HomeViewPageAdapter(requireContext(), images)
         binding.imageViewItemDayCurrentDate.adapter = adapter
         updateImageNum(0, images.size)
         binding.imageViewItemDayCurrentDate.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {

--- a/app/src/main/java/com/fitmate/fitmate/presentation/ui/home/HomeMainFragment.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/ui/home/HomeMainFragment.kt
@@ -73,7 +73,9 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
                             percent = formatPercent(cert),
                             time = formatDate(cert),
                             image = cert.multiMediaEndPoints.firstOrNull() ?: "",
-                            groupId = group.groupId
+                            groupId = group.groupId,
+                            startTime = null,
+                            endTime = null
                         )}}.flatten().distinctBy { it.title + it.fitMate + it.time }
                 val voteAdapter = binding.recyclerViewHomeMain.adapter as VoteAdapter
                 voteAdapter.submitList(voteItems)

--- a/app/src/main/java/com/fitmate/fitmate/presentation/ui/home/list/adapter/HomeViewPageAdapter.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/ui/home/list/adapter/HomeViewPageAdapter.kt
@@ -9,10 +9,10 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.fitmate.fitmate.R
 
-class ImageSliderAdapter(
+class HomeViewPageAdapter(
     val context: Context,
     private val images: List<String>
-) : RecyclerView.Adapter<ImageSliderAdapter.ImageViewHolder>() {
+) : RecyclerView.Adapter<HomeViewPageAdapter.ImageViewHolder>() {
 
     inner class ImageViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val imageView: ImageView = view.findViewById(R.id.imageView)

--- a/app/src/main/java/com/fitmate/fitmate/presentation/ui/myfit/list/DayViewHolder.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/ui/myfit/list/DayViewHolder.kt
@@ -14,6 +14,8 @@ class DayViewHolder(
     private val onItemClick: (position: Int) -> Unit
 ) : RecyclerView.ViewHolder(view) {
     private val binding = ItemListDayBinding.bind(view)
+    private var lastClickTime = 0L
+    private val debouncePeriod = 500 // 500 milliseconds
 
     private val fitDates = listOf( // TODO 예시데이터를 집어넣은 것으로, 해당 달에 운동한 날짜의 데이터를 모두 가져와 해당 리스트에 담아야 함.
         LocalDate.of(2024, 4, 14),
@@ -48,6 +50,18 @@ class DayViewHolder(
 
         binding.root.setOnClickListener {
             onItemClick(date.dayOfMonth)
+        }
+    }
+
+    init {
+        binding.root.setOnClickListener {
+            val currentTime = System.currentTimeMillis()
+            if (currentTime - lastClickTime > debouncePeriod) {
+                lastClickTime = currentTime
+                onItemClick(adapterPosition)
+            } else {
+                onItemClick(0)
+            }
         }
     }
 }

--- a/app/src/main/java/com/fitmate/fitmate/presentation/viewmodel/ChattingViewModel.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/viewmodel/ChattingViewModel.kt
@@ -8,8 +8,10 @@ import com.fitmate.fitmate.data.model.dto.ChatResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import androidx.lifecycle.viewModelScope
+import com.fitmate.fitmate.data.model.dto.EachFitResponse
 import com.fitmate.fitmate.data.model.entity.ChatEntity
 import com.fitmate.fitmate.domain.usecase.DBChatUseCase
+import com.fitmate.fitmate.domain.usecase.GroupUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -29,22 +31,6 @@ class ChattingViewModel @Inject constructor(
 
     private val _lastChatItem = MutableLiveData<ChatEntity?>()
     val lastChatItem: LiveData<ChatEntity?> = _lastChatItem
-
-//    fun retrieveMessage(messageId: String, fitGroupId: Int, fitMateId: Int, messageTime: String, messageType: String) {
-//        viewModelScope.launch {
-//            _isLoading.value = true
-//            val response = networkUseCase.retrieveMessage(messageId, fitGroupId, fitMateId, messageTime, messageType)
-//
-//            withContext(Dispatchers.Main) {
-//                if (response.isSuccessful) {
-//                    _chatResponse.value = response.body()
-//                }
-//                _isLoading.value = false
-//            }
-//        }
-//    }
-// TODO 지금은 임시지만 나중에 채팅이 다른 디바이스에서도 서로 통신이 가능할 경우, 해당 함수를 사용해야 함.
-// TODO 현재는 기기 1개 fitmateId 1개로 해서 이렇게 될 수 밖에 없지만, 추후에 복수 이상의 fitMateId가 들어오고 서로 채팅을 치고 안보는 상황에 해당 함수를 사용해야 함.
 
     fun retrieveMessage() {
         viewModelScope.launch {
@@ -87,5 +73,4 @@ class ChattingViewModel @Inject constructor(
     private fun formatCustomDateTime(isoDateTime: String): String {
         return isoDateTime.replace("T", " ")
     }
-
 }

--- a/app/src/main/java/com/fitmate/fitmate/presentation/viewmodel/GroupViewModel.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/viewmodel/GroupViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.fitmate.fitmate.data.model.dto.EachFitResponse
 import com.fitmate.fitmate.data.model.dto.GroupDetailResponse
 import com.fitmate.fitmate.data.model.dto.GroupResponse
 import com.fitmate.fitmate.domain.usecase.GroupUseCase
@@ -19,6 +20,9 @@ class GroupViewModel @Inject constructor(private val groupUseCase: GroupUseCase)
     private val _groupDetail = MutableLiveData<GroupDetailResponse>()
     val groupDetail: LiveData<GroupDetailResponse> = _groupDetail
 
+    private val _fitGroupVotes = MutableLiveData<EachFitResponse>()
+    val fitGroupVotes: LiveData<EachFitResponse> = _fitGroupVotes
+
     fun getFitGroups(withMaxGroup: Boolean, category: Int, pageNumber: Int, pageSize: Int) {
         viewModelScope.launch {
             val response = groupUseCase(withMaxGroup, category, pageNumber, pageSize)
@@ -30,6 +34,14 @@ class GroupViewModel @Inject constructor(private val groupUseCase: GroupUseCase)
         viewModelScope.launch{
             val response = groupUseCase(fitGroupId)
             _groupDetail.value = response
+        }
+    }
+    fun fetchFitGroupVotes() {
+        viewModelScope.launch {
+            val response = groupUseCase.eachFitGroupVotes()
+            if(response.isSuccessful) {
+                _fitGroupVotes.postValue(response.body())
+            }
         }
     }
 }

--- a/app/src/main/java/com/fitmate/fitmate/presentation/viewmodel/HomeMainViewModel.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/viewmodel/HomeMainViewModel.kt
@@ -19,7 +19,7 @@ class HomeMainViewModel @Inject constructor(
 
     fun fetchMyFitGroupVotes() {
         viewModelScope.launch {
-            val result = groupUseCase.fetchFitVotes()
+            val result = groupUseCase.myFitGroupVotes()
             _fitGroupVotes.value = result
         }
     }

--- a/app/src/main/res/layout/dialog_vote_image_slider.xml
+++ b/app/src/main/res/layout/dialog_vote_image_slider.xml
@@ -1,0 +1,27 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/viewPagerDialogVote"
+        android:layout_width="match_parent"
+        android:layout_height="200dp" />
+
+    <TextView
+        android:id="@+id/textViewDialogVoteHour"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text=""
+        android:layout_marginTop="8dp" />
+
+    <TextView
+        android:id="@+id/textViewDialogVoteTime"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text=""
+        android:layout_marginTop="8dp" />
+
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_chatting.xml
+++ b/app/src/main/res/layout/fragment_chatting.xml
@@ -218,7 +218,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
                     android:backgroundTint="@color/stateBlue"
-                    app:icon="@drawable/ic_baseline_rest_24"
+                    app:icon="@drawable/ic_baseline_send_money_24"
                     app:layout_constraintStart_toStartOf="@+id/buttonFragmentChattingFitMateProgress"
                     app:layout_constraintTop_toBottomOf="@+id/textViewFragmentChattingFitMateProgress" />
 
@@ -243,8 +243,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
                     android:backgroundTint="@color/stateBlue"
-                    app:icon="@drawable/ic_baseline_rest_24"
-                    app:layout_constraintHorizontal_bias="0.5"
+                    app:icon="@drawable/ic_baseline_timer_24"
                     app:layout_constraintStart_toStartOf="@+id/buttonFragmentChattingVote"
                     app:layout_constraintTop_toBottomOf="@+id/textViewFragmentChattingFitMateProgress" />
 

--- a/app/src/main/res/layout/fragment_group_vote.xml
+++ b/app/src/main/res/layout/fragment_group_vote.xml
@@ -19,18 +19,40 @@
             android:layout_height="wrap_content"
             app:title="@string/group_vote_scr_toolbar" />
 
-        <LinearLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_margin="10dp"
-            android:orientation="vertical">
+            android:layout_margin="10dp">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recyclerGroupVote"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 tools:listitem="@layout/item_vote" />
-        </LinearLayout>
+
+            <com.facebook.shimmer.ShimmerFrameLayout
+                android:id="@+id/groupVoteShimmer"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:visibility="gone">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical">
+
+                    <include layout="@layout/item_category_shimmer" />
+                    <include layout="@layout/item_category_shimmer" />
+                    <include layout="@layout/item_category_shimmer" />
+                    <include layout="@layout/item_category_shimmer" />
+                    <include layout="@layout/item_category_shimmer" />
+                    <include layout="@layout/item_category_shimmer" />
+
+                </LinearLayout>
+
+            </com.facebook.shimmer.ShimmerFrameLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_home_category.xml
+++ b/app/src/main/res/layout/fragment_home_category.xml
@@ -187,10 +187,7 @@
                     <include layout="@layout/item_category_shimmer" />
 
                 </LinearLayout>
-
             </com.facebook.shimmer.ShimmerFrameLayout>
-
-
         </androidx.constraintlayout.widget.ConstraintLayout>
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_user_info.xml
+++ b/app/src/main/res/layout/fragment_user_info.xml
@@ -58,7 +58,8 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="2">
+            android:layout_weight="2"
+            android:background="@color/zircon">
 
             <TextView
                 android:id="@+id/textViewUserInfoTitle1"

--- a/app/src/main/res/navigation/nav_main_graph.xml
+++ b/app/src/main/res/navigation/nav_main_graph.xml
@@ -133,7 +133,7 @@
     <fragment
         android:id="@+id/groupVoteFragment2"
         android:name="com.fitmate.fitmate.presentation.ui.chatting.GroupVoteFragment"
-        android:label="GroupVoteFragment" />
+        android:label="@string/group_vote_scr_toolbar" />
     <fragment
         android:id="@+id/loginWebViewFragment"
         android:name="com.fitmate.fitmate.presentation.ui.login.LoginWebViewFragment"


### PR DESCRIPTION
채팅 플러스 메뉴 기능 구현
[1] 송금 코드 복사 클릭 시 해당 피트그룹 계좌번호 복사
[2] 그룹 별 투표 화면 해당 피트그룹에 올라온 투표 추가
[3] 해당 투표 클릭 시 상세 사진 및 시간 추가
+ 3번의 상세 사진은 아직 추가되지 않아 추후 별도로 추가 예정