### PR TITLE
오픈소스 라이선스 고지 업데이트 #2

### DIFF
--- a/app/src/main/java/com/fitmate/fitmate/presentation/ui/userinfo/LicenseFragment.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/ui/userinfo/LicenseFragment.kt
@@ -33,7 +33,7 @@ class LicenseFragment: Fragment(R.layout.fragment_license) {
 
     private fun setupRecyclerView() {
         binding.recyclerViewLicense.layoutManager = LinearLayoutManager(context)
-        binding.recyclerViewLicense.adapter = LicenseAdapter()
+        binding.recyclerViewLicense.adapter = LicenseAdapter(this)
         val divider = DividerItemDecoration(context, LinearLayoutManager.VERTICAL)
         binding.recyclerViewLicense.addItemDecoration(divider)
     }

--- a/app/src/main/java/com/fitmate/fitmate/presentation/ui/userinfo/list/LicenseData.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/ui/userinfo/list/LicenseData.kt
@@ -8,79 +8,410 @@ object LicenseData {
             name = "Google Android Libraries",
             url = "https://developer.android.com/",
             copyright = "Copyright © Google LLC",
-            license = "Apache License 2.0"
+            license = "[ Apache License 2.0 ]"
         ),
         LicenseItem(
             name = "Hilt",
             url = "https://dagger.dev/hilt/",
             copyright = "Copyright © Google LLC",
-            license = "Apache License 2.0"
+            license = "[ Apache License 2.0 ]"
         ),
         LicenseItem(
             name = "Firebase",
             url = "https://firebase.google.com/",
             copyright = "Copyright © Google LLC",
-            license = "Terms of Service (commercial use permitted)"
+            license = "[ Apache License 2.0 ]"
         ),
         LicenseItem(
             name = "Retrofit",
             url = "https://github.com/square/retrofit",
             copyright = "Copyright © Square, Inc.",
-            license = "Apache License 2.0"
+            license = "[ Apache License 2.0 ]"
         ),
         LicenseItem(
             name = "OkHttp",
             url = "https://github.com/square/okhttp",
             copyright = "Copyright © Square, Inc.",
-            license = "Apache License 2.0"
+            license = "[ Apache License 2.0 ]"
         ),
         LicenseItem(
             name = "JUnit",
             url = "https://junit.org/junit5/",
             copyright = "Copyright © JUnit Team",
-            license = "Eclipse Public License 1.0"
+            license = "[ Eclipse Public License 1.0 ]"
         ),
         LicenseItem(
             name = "Espresso",
             url = "https://developer.android.com/training/testing/espresso",
             copyright = "Copyright © Google LLC",
-            license = "Apache License 2.0"
+            license = "[ Apache License 2.0 ]"
         ),
         LicenseItem(
             name = "Lottie",
             url = "https://github.com/airbnb/lottie-android",
             copyright = "Copyright © Airbnb, Inc.",
-            license = "Apache License 2.0"
+            license = "[ Apache License 2.0 ]"
         ),
         LicenseItem(
             name = "Glide",
             url = "https://github.com/bumptech/glide",
             copyright = "Copyright © 2014-present, Sam Judd",
-            license = "BSD, Glide's custom license"
+            license = "[ BSD License ]"
         ),
         LicenseItem(
             name = "IconScout Icons",
             url = "https://iconscout.com/",
             copyright = "Copyright © 2022 Design Barn Inc.",
-            license = "IconScout Simple License"
+            license = "[ IconScout Simple License ]"
         ),
         LicenseItem(
             name = "HorizontalNestedScrollView",
             url = "https://github.com/Tans5/horizontalnestedscrollview",
             copyright = "Copyright © 2023, Tans5",
-            license = "MIT License"
+            license = "[ MIT License ]"
         ),
         LicenseItem(
             name = "Compressor",
             url = "https://github.com/zetbaitsu/Compressor",
             copyright = "Copyright © Zelory",
-            license = "Apache License 2.0"
+            license = "[ Apache License 2.0 ]"
         ),
         LicenseItem(
             name = "Shimmer for Android",
             url = "https://github.com/facebook/shimmer-android",
             copyright = "Copyright © Facebook, Inc.",
-            license = "MIT License"
+            license = "[ MIT License ]"
         ),
     )
+
+    val apacheLicenseText = "     Apache License\n" +
+            "                           Version 2.0, January 2004\n" +
+            "                        http://www.apache.org/licenses/\n" +
+            "\n" +
+            "   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n" +
+            "\n" +
+            "   1. Definitions.\n" +
+            "\n" +
+            "      \"License\" shall mean the terms and conditions for use, reproduction,\n" +
+            "      and distribution as defined by Sections 1 through 9 of this document.\n" +
+            "\n" +
+            "      \"Licensor\" shall mean the copyright owner or entity authorized by\n" +
+            "      the copyright owner that is granting the License.\n" +
+            "\n" +
+            "      \"Legal Entity\" shall mean the union of the acting entity and all\n" +
+            "      other entities that control, are controlled by, or are under common\n" +
+            "      control with that entity. For the purposes of this definition,\n" +
+            "      \"control\" means (i) the power, direct or indirect, to cause the\n" +
+            "      direction or management of such entity, whether by contract or\n" +
+            "      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n" +
+            "      outstanding shares, or (iii) beneficial ownership of such entity.\n" +
+            "\n" +
+            "      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n" +
+            "      exercising permissions granted by this License.\n" +
+            "\n" +
+            "      \"Source\" form shall mean the preferred form for making modifications,\n" +
+            "      including but not limited to software source code, documentation\n" +
+            "      source, and configuration files.\n" +
+            "\n" +
+            "      \"Object\" form shall mean any form resulting from mechanical\n" +
+            "      transformation or translation of a Source form, including but\n" +
+            "      not limited to compiled object code, generated documentation,\n" +
+            "      and conversions to other media types.\n" +
+            "\n" +
+            "      \"Work\" shall mean the work of authorship, whether in Source or\n" +
+            "      Object form, made available under the License, as indicated by a\n" +
+            "      copyright notice that is included in or attached to the work\n" +
+            "      (an example is provided in the Appendix below).\n" +
+            "\n" +
+            "      \"Derivative Works\" shall mean any work, whether in Source or Object\n" +
+            "      form, that is based on (or derived from) the Work and for which the\n" +
+            "      editorial revisions, annotations, elaborations, or other modifications\n" +
+            "      represent, as a whole, an original work of authorship. For the purposes\n" +
+            "      of this License, Derivative Works shall not include works that remain\n" +
+            "      separable from, or merely link (or bind by name) to the interfaces of,\n" +
+            "      the Work and Derivative Works thereof.\n" +
+            "\n" +
+            "      \"Contribution\" shall mean any work of authorship, including\n" +
+            "      the original version of the Work and any modifications or additions\n" +
+            "      to that Work or Derivative Works thereof, that is intentionally\n" +
+            "      submitted to Licensor for inclusion in the Work by the copyright owner\n" +
+            "      or by an individual or Legal Entity authorized to submit on behalf of\n" +
+            "      the copyright owner. For the purposes of this definition, \"submitted\"\n" +
+            "      means any form of electronic, verbal, or written communication sent\n" +
+            "      to the Licensor or its representatives, including but not limited to\n" +
+            "      communication on electronic mailing lists, source code control systems,\n" +
+            "      and issue tracking systems that are managed by, or on behalf of, the\n" +
+            "      Licensor for the purpose of discussing and improving the Work, but\n" +
+            "      excluding communication that is conspicuously marked or otherwise\n" +
+            "      designated in writing by the copyright owner as \"Not a Contribution.\"\n" +
+            "\n" +
+            "      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n" +
+            "      on behalf of whom a Contribution has been received by Licensor and\n" +
+            "      subsequently incorporated within the Work.\n" +
+            "\n" +
+            "   2. Grant of Copyright License. Subject to the terms and conditions of\n" +
+            "      this License, each Contributor hereby grants to You a perpetual,\n" +
+            "      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n" +
+            "      copyright license to reproduce, prepare Derivative Works of,\n" +
+            "      publicly display, publicly perform, sublicense, and distribute the\n" +
+            "      Work and such Derivative Works in Source or Object form.\n" +
+            "\n" +
+            "   3. Grant of Patent License. Subject to the terms and conditions of\n" +
+            "      this License, each Contributor hereby grants to You a perpetual,\n" +
+            "      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n" +
+            "      (except as stated in this section) patent license to make, have made,\n" +
+            "      use, offer to sell, sell, import, and otherwise transfer the Work,\n" +
+            "      where such license applies only to those patent claims licensable\n" +
+            "      by such Contributor that are necessarily infringed by their\n" +
+            "      Contribution(s) alone or by combination of their Contribution(s)\n" +
+            "      with the Work to which such Contribution(s) was submitted. If You\n" +
+            "      institute patent litigation against any entity (including a\n" +
+            "      cross-claim or counterclaim in a lawsuit) alleging that the Work\n" +
+            "      or a Contribution incorporated within the Work constitutes direct\n" +
+            "      or contributory patent infringement, then any patent licenses\n" +
+            "      granted to You under this License for that Work shall terminate\n" +
+            "      as of the date such litigation is filed.\n" +
+            "\n" +
+            "   4. Redistribution. You may reproduce and distribute copies of the\n" +
+            "      Work or Derivative Works thereof in any medium, with or without\n" +
+            "      modifications, and in Source or Object form, provided that You\n" +
+            "      meet the following conditions:\n" +
+            "\n" +
+            "      (a) You must give any other recipients of the Work or\n" +
+            "          Derivative Works a copy of this License; and\n" +
+            "\n" +
+            "      (b) You must cause any modified files to carry prominent notices\n" +
+            "          stating that You changed the files; and\n" +
+            "\n" +
+            "      (c) You must retain, in the Source form of any Derivative Works\n" +
+            "          that You distribute, all copyright, patent, trademark, and\n" +
+            "          attribution notices from the Source form of the Work,\n" +
+            "          excluding those notices that do not pertain to any part of\n" +
+            "          the Derivative Works; and\n" +
+            "\n" +
+            "      (d) If the Work includes a \"NOTICE\" text file as part of its\n" +
+            "          distribution, then any Derivative Works that You distribute must\n" +
+            "          include a readable copy of the attribution notices contained\n" +
+            "          within such NOTICE file, excluding those notices that do not\n" +
+            "          pertain to any part of the Derivative Works, in at least one\n" +
+            "          of the following places: within a NOTICE text file distributed\n" +
+            "          as part of the Derivative Works; within the Source form or\n" +
+            "          documentation, if provided along with the Derivative Works; or,\n" +
+            "          within a display generated by the Derivative Works, if and\n" +
+            "          wherever such third-party notices normally appear. The contents\n" +
+            "          of the NOTICE file are for informational purposes only and\n" +
+            "          do not modify the License. You may add Your own attribution\n" +
+            "          notices within Derivative Works that You distribute, alongside\n" +
+            "          or as an addendum to the NOTICE text from the Work, provided\n" +
+            "          that such additional attribution notices cannot be construed\n" +
+            "          as modifying the License.\n" +
+            "\n" +
+            "      You may add Your own copyright statement to Your modifications and\n" +
+            "      may provide additional or different license terms and conditions\n" +
+            "      for use, reproduction, or distribution of Your modifications, or\n" +
+            "      for any such Derivative Works as a whole, provided Your use,\n" +
+            "      reproduction, and distribution of the Work otherwise complies with\n" +
+            "      the conditions stated in this License.\n" +
+            "\n" +
+            "   5. Submission of Contributions. Unless You explicitly state otherwise,\n" +
+            "      any Contribution intentionally submitted for inclusion in the Work\n" +
+            "      by You to the Licensor shall be under the terms and conditions of\n" +
+            "      this License, without any additional terms or conditions.\n" +
+            "      Notwithstanding the above, nothing herein shall supersede or modify\n" +
+            "      the terms of any separate license agreement you may have executed\n" +
+            "      with Licensor regarding such Contributions.\n" +
+            "\n" +
+            "   6. Trademarks. This License does not grant permission to use the trade\n" +
+            "      names, trademarks, service marks, or product names of the Licensor,\n" +
+            "      except as required for reasonable and customary use in describing the\n" +
+            "      origin of the Work and reproducing the content of the NOTICE file.\n" +
+            "\n" +
+            "   7. Disclaimer of Warranty. Unless required by applicable law or\n" +
+            "      agreed to in writing, Licensor provides the Work (and each\n" +
+            "      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n" +
+            "      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n" +
+            "      implied, including, without limitation, any warranties or conditions\n" +
+            "      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n" +
+            "      PARTICULAR PURPOSE. You are solely responsible for determining the\n" +
+            "      appropriateness of using or redistributing the Work and assume any\n" +
+            "      risks associated with Your exercise of permissions under this License.\n" +
+            "\n" +
+            "   8. Limitation of Liability. In no event and under no legal theory,\n" +
+            "      whether in tort (including negligence), contract, or otherwise,\n" +
+            "      unless required by applicable law (such as deliberate and grossly\n" +
+            "      negligent acts) or agreed to in writing, shall any Contributor be\n" +
+            "      liable to You for damages, including any direct, indirect, special,\n" +
+            "      incidental, or consequential damages of any character arising as a\n" +
+            "      result of this License or out of the use or inability to use the\n" +
+            "      Work (including but not limited to damages for loss of goodwill,\n" +
+            "      work stoppage, computer failure or malfunction, or any and all\n" +
+            "      other commercial damages or losses), even if such Contributor\n" +
+            "      has been advised of the possibility of such damages.\n" +
+            "\n" +
+            "   9. Accepting Warranty or Additional Liability. While redistributing\n" +
+            "      the Work or Derivative Works thereof, You may choose to offer,\n" +
+            "      and charge a fee for, acceptance of support, warranty, indemnity,\n" +
+            "      or other liability obligations and/or rights consistent with this\n" +
+            "      License. However, in accepting such obligations, You may act only\n" +
+            "      on Your own behalf and on Your sole responsibility, not on behalf\n" +
+            "      of any other Contributor, and only if You agree to indemnify,\n" +
+            "      defend, and hold each Contributor harmless for any liability\n" +
+            "      incurred by, or claims asserted against, such Contributor by reason\n" +
+            "      of your accepting any such warranty or additional liability.\n" +
+            "\n" +
+            "   END OF TERMS AND CONDITIONS\n" +
+            "\n" +
+            "   APPENDIX: How to apply the Apache License to your work.\n" +
+            "\n" +
+            "      To apply the Apache License to your work, attach the following\n" +
+            "      boilerplate notice, with the fields enclosed by brackets \"[]\"\n" +
+            "      replaced with your own identifying information. (Don't include\n" +
+            "      the brackets!)  The text should be enclosed in the appropriate\n" +
+            "      comment syntax for the file format. We also recommend that a\n" +
+            "      file or class name and description of purpose be included on the\n" +
+            "      same \"printed page\" as the copyright notice for easier\n" +
+            "      identification within third-party archives.\n" +
+            "\n" +
+            "   Copyright 2024 FITMAT]\n" +
+            "\n" +
+            "   Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
+            "   you may not use this file except in compliance with the License.\n" +
+            "   You may obtain a copy of the License at\n" +
+            "\n" +
+            "       http://www.apache.org/licenses/LICENSE-2.0\n" +
+            "\n" +
+            "   Unless required by applicable law or agreed to in writing, software\n" +
+            "   distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
+            "   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
+            "   See the License for the specific language governing permissions and\n" +
+            "   limitations under the License."
+
+    val mitLicenseText = "MIT License\n" +
+            "\n" +
+            "Copyright (c) 2024 FITMATE\n" +
+            "\n" +
+            "Permission is hereby granted, free of charge, to any person obtaining a copy\n" +
+            "of this software and associated documentation files (the \"Software\"), to deal\n" +
+            "in the Software without restriction, including without limitation the rights\n" +
+            "to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n" +
+            "copies of the Software, and to permit persons to whom the Software is\n" +
+            "furnished to do so, subject to the following conditions:\n" +
+            "\n" +
+            "The above copyright notice and this permission notice shall be included in all\n" +
+            "copies or substantial portions of the Software.\n" +
+            "\n" +
+            "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR" +
+            "IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY," +
+            "FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE" +
+            "AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER" +
+            "LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM," +
+            "OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE" +
+            "SOFTWARE."
+
+    val iconScoutText = "Permission is hereby granted, free of charge, to any person obtaining a copy of the asset files available for download at the IconScout site (“Files”). To download, modify, and use digitally such Files, for commercial purposes, provided that any display, publication, or performance of Files must contain (and be subject to) the same terms and conditions of this license. Modifications to Files are deemed derivative works and can be used for commercial as well as personal projects but are not allowed to resell or republish( as a separate entity under any other profile) to any platform. You may not purport to impose any additional or different terms or conditions on or apply any technical measures that restrict the exercise of, the rights granted under this license.\n" +
+            "\n" +
+            "This license does not include the right to collect or compile Files from IconScout to replicate or develop a similar or competing service.\n" +
+            "\n" +
+            "Use of Files in your product or project without attributing the creator(s) of the Files is permitted under this license, though attribution is strongly encouraged. If attributions are included, such attributions should be visible to the end-user. However, Any assets uploaded or published by you of which you are not the original designer but you have edited in some way must have the original creator attributed and a link provided to the original animation in the description. If you fail to do this, the upload falls under the category of plagiarised content can be reported and may be removed from IconScout.\n" +
+            "\n" +
+            "FILES ARE PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW, IN NO EVENT WILL THE CREATOR(S) OF FILES OR DESIGN BARN, INC. BE LIABLE ON ANY LEGAL THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE, OR EXEMPLARY DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF SUCH FILES."
+
+    val bsdLicenseText = "Note: This license has also been called the “Simplified BSD License” and the “FreeBSD License”. See also the 3-clause BSD License.\n" +
+            "\n" +
+            "Copyright 2024 FITMATE\n" +
+            "\n" +
+            "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\n" +
+            "\n" +
+            "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.\n" +
+            "\n" +
+            "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.\n" +
+            "\n" +
+            "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+
+    val eclipseLicenseText = "Eclipse Public License - v 1.0\n" +
+            "THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (\"AGREEMENT\"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.\n" +
+            "\n" +
+            "1. DEFINITIONS\n" +
+            "\n" +
+            "\"Contribution\" means:\n" +
+            "\n" +
+            "a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and\n" +
+            "\n" +
+            "b) in the case of each subsequent Contributor:\n" +
+            "\n" +
+            "i) changes to the Program, and\n" +
+            "\n" +
+            "ii) additions to the Program;\n" +
+            "\n" +
+            "where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution 'originates' from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.\n" +
+            "\n" +
+            "\"Contributor\" means any person or entity that distributes the Program.\n" +
+            "\n" +
+            "\"Licensed Patents\" mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.\n" +
+            "\n" +
+            "\"Program\" means the Contributions distributed in accordance with this Agreement.\n" +
+            "\n" +
+            "\"Recipient\" means anyone who receives the Program under this Agreement, including all Contributors.\n" +
+            "\n" +
+            "2. GRANT OF RIGHTS\n" +
+            "\n" +
+            "a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.\n" +
+            "\n" +
+            "b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.\n" +
+            "\n" +
+            "c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.\n" +
+            "\n" +
+            "d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.\n" +
+            "\n" +
+            "3. REQUIREMENTS\n" +
+            "\n" +
+            "A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:\n" +
+            "\n" +
+            "a) it complies with the terms and conditions of this Agreement; and\n" +
+            "\n" +
+            "b) its license agreement:\n" +
+            "\n" +
+            "i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;\n" +
+            "\n" +
+            "ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;\n" +
+            "\n" +
+            "iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and\n" +
+            "\n" +
+            "iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.\n" +
+            "\n" +
+            "When the Program is made available in source code form:\n" +
+            "\n" +
+            "a) it must be made available under this Agreement; and\n" +
+            "\n" +
+            "b) a copy of this Agreement must be included with each copy of the Program.\n" +
+            "\n" +
+            "Contributors may not remove or alter any copyright notices contained within the Program.\n" +
+            "\n" +
+            "Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.\n" +
+            "\n" +
+            "4. COMMERCIAL DISTRIBUTION\n" +
+            "\n" +
+            "Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (\"Commercial Contributor\") hereby agrees to defend and indemnify every other Contributor (\"Indemnified Contributor\") against any losses, damages and costs (collectively \"Losses\") arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.\n" +
+            "\n" +
+            "For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.\n" +
+            "\n" +
+            "5. NO WARRANTY\n" +
+            "\n" +
+            "EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.\n" +
+            "\n" +
+            "6. DISCLAIMER OF LIABILITY\n" +
+            "\n" +
+            "EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.\n" +
+            "\n" +
+            "7. GENERAL\n" +
+            "\n" +
+            "If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.\n" +
+            "\n" +
+            "If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.\n" +
+            "\n" +
+            "All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.\n" +
+            "\n" +
+            "Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.\n" +
+            "\n" +
+            "This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation."
 }

--- a/app/src/main/java/com/fitmate/fitmate/presentation/ui/userinfo/list/LicenseViewHolder.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/ui/userinfo/list/LicenseViewHolder.kt
@@ -3,17 +3,34 @@ package com.fitmate.fitmate.presentation.ui.userinfo.list
 import android.content.Intent
 import android.graphics.Paint
 import android.net.Uri
+import androidx.core.content.ContentProviderCompat.requireContext
+import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
+import com.fitmate.fitmate.R
 import com.fitmate.fitmate.databinding.ItemLicenseBinding
 import com.fitmate.fitmate.domain.model.LicenseItem
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
-class LicenseViewHolder(private val binding: ItemLicenseBinding): RecyclerView.ViewHolder(binding.root) {
+class LicenseViewHolder(private val fragment: Fragment, private val binding: ItemLicenseBinding): RecyclerView.ViewHolder(binding.root) {
 
     fun bind(item: LicenseItem) {
         binding.data = item
         binding.textViewLicenseItemLink.paintFlags = Paint.UNDERLINE_TEXT_FLAG
         binding.textViewLicenseItemLink.setOnClickListener {
             itemView.context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(item.url)))
+        }
+        binding.textViewLicenseItemlicense.setOnClickListener {
+            val licenseText = when(binding.textViewLicenseItemlicense.text) {
+                "[ Apache License 2.0 ]" -> LicenseData.apacheLicenseText
+                "[ MIT License ]" -> LicenseData.mitLicenseText
+                "[ IconScout Simple License ]" -> LicenseData.iconScoutText
+                "[ BSD License ]" -> LicenseData.bsdLicenseText
+                "[ Eclipse Public License 1.0 ]" -> LicenseData.eclipseLicenseText
+                else -> ""
+            }
+            MaterialAlertDialogBuilder(fragment.requireContext(), R.style.Theme_Fitmate_license)
+                .setMessage(licenseText)
+                .show()
         }
     }
 }

--- a/app/src/main/java/com/fitmate/fitmate/presentation/ui/userinfo/list/adapter/LicenseAdapter.kt
+++ b/app/src/main/java/com/fitmate/fitmate/presentation/ui/userinfo/list/adapter/LicenseAdapter.kt
@@ -2,17 +2,18 @@ package com.fitmate.fitmate.presentation.ui.userinfo.list.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.fitmate.fitmate.databinding.ItemLicenseBinding
 import com.fitmate.fitmate.domain.model.LicenseItem
 import com.fitmate.fitmate.presentation.ui.userinfo.list.LicenseViewHolder
 
-class LicenseAdapter(): ListAdapter<LicenseItem, LicenseViewHolder>(LicenseProgressDiffCallback) {
+class LicenseAdapter(private val fragment: Fragment): ListAdapter<LicenseItem, LicenseViewHolder>(LicenseProgressDiffCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LicenseViewHolder {
         val binding = ItemLicenseBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return LicenseViewHolder(binding)
+        return LicenseViewHolder(fragment, binding)
     }
 
     override fun onBindViewHolder(holder: LicenseViewHolder, position: Int) {

--- a/app/src/main/res/layout/item_license.xml
+++ b/app/src/main/res/layout/item_license.xml
@@ -35,7 +35,14 @@
             android:id="@+id/textViewLicenseItemCopyright"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@{data.copyright + ` | ` + data.license}"
+            android:text="@{data.copyright}"
+            android:textAppearance="@style/Font.regular12" />
+
+        <TextView
+            android:id="@+id/textViewLicenseItemlicense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@{data.license}"
             android:textAppearance="@style/Font.regular12" />
 
     </LinearLayout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -26,5 +26,11 @@
         <item name="android:background">@color/zircon</item>
     </style>
 
+    <style name="Theme.Fitmate.license" parent="ThemeOverlay.Material3.MaterialAlertDialog">
+        <item name="android:fontFamily">@font/pretendard_medium</item>
+        <item name="android:background">@color/zircon</item>
+        <item name="android:textSize">@dimen/text_XS</item>
+    </style>
+
 
 </resources>


### PR DESCRIPTION
라이선스 고지 시,
오픈소스명, 홈페이지, 라이선스 종류 및 공식문서를 넣어야 하는데,
공식문서를 누락하여 다이얼로그로 추가